### PR TITLE
Issue#2 requests cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #########################################
 # Custom #
 *__htmlcache__/
+*.sqlite
 
 #########################################
 # Editor temporary/working/backup files #

--- a/pyAFL/conftest.py
+++ b/pyAFL/conftest.py
@@ -1,16 +1,17 @@
+import os
 import pytest
+import requests_cache
 from unittest import mock
 
 from pyAFL.requests import requests
 
 
-@pytest.fixture(scope="session")
-def test_html_cache_path(tmpdir_factory):
-    fn = tmpdir_factory.mktemp("__HTMLCACHE__")
-    return fn
-
-
-@pytest.fixture
-def mock_html_cache_dir(monkeypatch, test_html_cache_path):
-    monkeypatch.setattr(requests, "get_html_cache_path", mock.Mock())
-    requests.get_html_cache_path.return_value = str(test_html_cache_path)
+@pytest.fixture(autouse=True)
+def create_test_db_before_test(request):
+    filepath = os.path.join(os.getcwd(), "test_db.sqlite")
+    if os.path.isfile(filepath):
+        os.remove(filepath)
+    requests_cache.install_cache("test_db", backend="sqlite")
+    yield
+    if os.path.isfile(filepath):
+        os.remove(filepath)

--- a/pyAFL/conftest.py
+++ b/pyAFL/conftest.py
@@ -11,7 +11,9 @@ def create_test_db_before_test(request):
     filepath = os.path.join(os.getcwd(), "test_db.sqlite")
     if os.path.isfile(filepath):
         os.remove(filepath)
-    requests_cache.install_cache("test_db", backend="sqlite")
+    requests_cache.install_cache(
+        "test_db", backend="sqlite", session_factory=requests.AFLTablesCachedSession
+    )
     yield
     if os.path.isfile(filepath):
         os.remove(filepath)

--- a/pyAFL/players/tests/test_models.py
+++ b/pyAFL/players/tests/test_models.py
@@ -11,7 +11,7 @@ class TestPlayerModel:
         with pytest.raises(TypeError):
             Player()
 
-    def test_player_classmethod_get_player_url_success(self, mock_html_cache_dir):
+    def test_player_classmethod_get_player_url_success(self):
         assert (
             Player("Nathan Brown")._get_player_url()
             == "https://afltables.com/afl/stats/players/N/Nathan_Brown0.html"
@@ -25,13 +25,13 @@ class TestPlayerModel:
             == "https://afltables.com/afl/stats/players/T/Tony_Lockett.html"
         )
 
-    def test_player_classmethod_get_player_url_failure(self, mock_html_cache_dir):
+    def test_player_classmethod_get_player_url_failure(self):
         with pytest.raises(LookupError) as e:
             Player("Babe Ruth")._get_player_url()
 
         assert "Found no players with name" in str(e)
 
-    def test_player_classmethod_get_player_stats(self, mock_html_cache_dir):
+    def test_player_classmethod_get_player_stats(self):
         player = Player("Nick Riewoldt")
 
         assert isinstance(player.get_player_stats(), PlayerStats)

--- a/pyAFL/requests/requests.py
+++ b/pyAFL/requests/requests.py
@@ -2,13 +2,16 @@ from bs4 import BeautifulSoup
 import os
 import re
 import requests as python_requests
+import requests_cache
+import sys
 import urllib
 
 from pyAFL import config
 
 
-def get_html_cache_path():
-    return os.path.join(os.getcwd(), "pyAFL/requests/__htmlcache__/")
+# Initalise cache backend
+cache_name = "test_db" if "pytest" in sys.modules else "pyAFL_html_cache"
+requests_cache.install_cache(cache_name, backend="sqlite")
 
 
 def get(url: str, force_live: bool = False):
@@ -40,17 +43,8 @@ def get(url: str, force_live: bool = False):
     # get full filepath
     base_url = config.AFLTABLES_STATS_BASE_URL
     url_path = url.split(base_url)[-1]
-    html_cache_path = get_html_cache_path()
-    filepath = os.path.join(html_cache_path, url_path)
 
-    if not force_live:
-        if os.path.isfile(filepath):
-            resp = python_requests.models.Response()
-            resp.url = url
-            resp.status_code = 200
-            with open(filepath, "r") as f:
-                resp._content = bytes(f.read(), "utf-8")
-            return resp
+    return python_requests.get(url)
 
     # otherwise make new live request and save html content to `__htmlcache__` directory
     resp = python_requests.get(url)

--- a/pyAFL/requests/tests/test_requests.py
+++ b/pyAFL/requests/tests/test_requests.py
@@ -32,7 +32,21 @@ class TestRequestCaching:
         url = "https://afltables.com/afl/stats/playersA_idx.html"
 
         resp1 = requests.get(url)
+        assert hasattr(resp1, "from_cache")
         assert not resp1.from_cache
 
         resp2 = requests.get(url)
+        assert hasattr(resp2, "from_cache")
         assert resp2.from_cache
+
+    def test_all_requests_with_force_live_are_not_from_cache(self):
+        url = "https://afltables.com/afl/stats/playersA_idx.html"
+
+        resp1 = requests.get(url, force_live=True)
+        assert not hasattr(resp1, "from_cache")
+
+        resp2 = requests.get(url, force_live=True)
+        assert not hasattr(resp2, "from_cache")
+
+        resp3 = requests.get(url, force_live=True)
+        assert not hasattr(resp3, "from_cache")

--- a/pyAFL/requests/tests/test_requests.py
+++ b/pyAFL/requests/tests/test_requests.py
@@ -28,56 +28,11 @@ class TestRequestCaching:
         with pytest.raises(AttributeError):
             resp = requests.get("https://abcdefgh")
 
-    def test_noncached_request_runs_successfully_and_creates_cached_html(
-        self, mock_python_get_request, mock_html_cache_dir
-    ):
-        test_path = os.path.join(
-            requests.get_html_cache_path(), "players/TEST/FAKE_PLAYER.html"
-        )
+    def test_second_request_is_from_cache(self):
+        url = "https://afltables.com/afl/stats/playersA_idx.html"
 
-        # assert cached file does not exist yet
-        assert not os.path.isfile(test_path)
+        resp1 = requests.get(url)
+        assert not resp1.from_cache
 
-        # make first request -> this will create the cached file
-        resp = requests.get(
-            "https://afltables.com/afl/stats/players/TEST/FAKE_PLAYER.html",
-            force_live=True,
-        )
-        assert resp.status_code == 200
-        assert "Hello test!" in resp.content.decode("utf-8")
-
-        assert os.path.isfile(test_path)
-        with open(test_path, "r") as f:
-            html_on_file = f.read()
-            assert "Hello test!" in html_on_file
-        os.remove(test_path)
-
-    def test_cached_request_fetches_from_cache_directory(
-        self, mock_html_cache_dir, mock_python_get_request, monkeypatch
-    ):
-        test_path = os.path.join(
-            requests.get_html_cache_path(), "players/TEST/TEST_PLAYER.html"
-        )
-        # assert cached file does not exist yet
-        assert not os.path.isfile(test_path)
-
-        # make first request -> this will create the cached file
-        requests.get(
-            "https://afltables.com/afl/stats/players/TEST/TEST_PLAYER.html",
-            force_live=True,
-        )
-
-        # change the `python_requests.get` mock return_value
-        resp2 = python_requests.models.Response()
-        resp2.status_code = 404
-        resp2._content = b"<html>Some error!</html>"
-        monkeypatch.setattr(python_requests, "get", mock.Mock())
-        python_requests.get.return_value = resp2
-
-        # make second request
-        resp = requests.get(
-            "https://afltables.com/afl/stats/players/TEST/TEST_PLAYER.html"
-        )
-
-        # assert resp has not changed (because we fetched from cache)
-        assert "Hello test!" in resp.content.decode("utf-8")
+        resp2 = requests.get(url)
+        assert resp2.from_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ python-dateutil==2.8.1
 pytz==2020.1
 regex==2020.9.27
 requests==2.24.0
+requests-cache==0.5.2
 six==1.15.0
 soupsieve==2.0.1
 toml==0.10.1


### PR DESCRIPTION
Patch for issue #2

- Implements requests-cache with an sqlite3 backend
- for request to afltables.com: converts relative URLs to absolute URLs
- escape hatch to allow end user to use base Python `requests` library as well (for requests to domains other than afltables.com) 
 