### PR TITLE
Issue#3 team model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pyAFL is a AFL (Australian Football League) data fetching libary. It scrapes dat
 - Player
   - [Player()](#Player)
   - [Player.get_player_stats()](#Player.get_player_stats)
+- Team
+  - [Team()](#Team)
+  - [Team.players](#Team.players)
+  - [Team.games](#Team.games)
 
 ### Player()
 
@@ -62,6 +66,60 @@ This function returns a PlayerStats object with attributes:
     >>> stats.season_results
         [  St Kilda - 2001   ...8 columns],    St Kilda - 2002  ...8 columns],    St Kilda - 2003  ...8 columns],    St Kilda - 2004  ...8 columns],    St Kilda - 2005  ...8 columns],    St Kilda - 2006  ...8 columns], ...]
 
+### Team()
+
+Instantiates a Team object. pyAFL automatically instantiates Team objects for all current and former AFL teams. They can be imported by their team abbreviation:
+
+    >>> from pyAFL.teams import (ADE, BRI, BRB, CAR, COL, ESS, FIZ, FRE, GEE, GC, GWS, HAW, MEL, NOR, POR, RIC, STK, SYD, UNI, WCE, WBD)
+    >>> # or
+    >>> from pyAFL.teams import ALL_TEAMS, CURRENT_TEAMS
+    
+    >>> ADE
+        <Team: Adelaide>
+    >>> CURRENT_TEAMS
+        [<Team: Adelaide>, <Team: Brisbane Lions>, <Team: Carlton>, <Team: Collingwood>, <Team: Essendon>, <Team: Fremantle>, <Team: Geelong>, <Team: Gold Coast>, <Team: Greater Western Sydney>, <Team: Hawthorn>, <Team: Melbourne>, <Team: North Melbourne>, <Team: Port Adelaide>, <Team: Richmond>, ...]
+
+### Team.players
+
+Returns a list of all historical player for this team. The list contains pyAFL [Player objects](#Player)
+
+    >>> from pyAFL.teams import ADE
+    >>> # Let's get a list of all players who have every played for Adelaide (i.e. all players from https://afltables.com/afl/stats/teams/adelaide.html)
+    >>> ADE.players
+        [<Player: Mcleod, Andrew>, <Player: Edwards, Tyson>, <Player: Ricciuto, Mark>, <Player: Hart, Ben>, <Player: Smart, Nigel>, <Player: Goodwin, Simon>, <Player: Bickley, Mark>, <Player: Thompson, Scott>, ...]
+
+### Team.games
+
+Returns a Pandas DataFrame with all historical game results for this team. The DataFrame has a datetime index.
+
+    >>> from pyAFL.teams import ADE
+    >>> # Let's get all historical game data (i.e. all the data from https://afltables.com/afl/teams/adelaide/allgames.html)
+    >>> ADE.games
+                             Rnd  T  ...    Crowd                      Date
+        Date                         ...                                   
+        1991-03-22 19:40:00   R1  H  ...  44902.0   Fri 22-Mar-1991 7:40 PM
+        1991-03-31 14:10:00   R2  H  ...  43850.0   Sun 31-Mar-1991 2:10 PM
+        ...                  ... ..  ...      ...                       ...
+        2020-09-13 13:05:00  R17  A  ...   2735.0   Sun 13-Sep-2020 1:05 PM
+        2020-09-19 16:40:00  R18  H  ...  17710.0   Sat 19-Sep-2020 4:40 PM
+        [688 rows x 13 columns]
+    
+    >>> # The DataFrame can be sliced by Date in human-readable format!
+    >>> ADE.games.loc['2016-01-01':'2019-12-31']
+                             Rnd  T  ...    Crowd                     Date
+        Date                         ...                                  
+        2016-03-26 19:25:00   R1  A  ...  25485.0  Sat 26-Mar-2016 7:25 PM
+        2016-04-02 13:15:00   R2  H  ...  50555.0  Sat 02-Apr-2016 1:15 PM
+        ...                  ... ..  ...      ...                      ...
+        2019-08-17 16:05:00  R22  H  ...  48175.0  Sat 17-Aug-2019 4:05 PM
+        2019-08-25 13:10:00  R23  A  ...   9560.0  Sun 25-Aug-2019 1:10 PM
+        [93 rows x 13 columns]
+    
+    >>> # Let's see what columns are contained in the DataFrame
+    >>> ADE.games.columns
+        Index(['Rnd', 'T', 'Opponent', 'Scoring', 'For', 'Scoring', 'Against', 'Result', 'Margin', 'W-D-L', 'Venue', 'Crowd', 'Date'], dtype='object')
+        
+        
 ## Testing
 
 The unit tests can be run by running pytest from the project directory, like so;

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Instantiates a Team object. pyAFL automatically instantiates Team objects for al
 
 ### Team.players
 
-Returns a list of all historical player for this team. The list contains pyAFL [Player objects](#Player)
+Returns a list of all historical players for this team. The return is a list of pyAFL [Player](#Player) objects. These Player objects can be queried to get player stats using the Player classmethods noted above.
 
     >>> from pyAFL.teams import ADE
     >>> # Let's get a list of all players who have every played for Adelaide (i.e. all players from https://afltables.com/afl/stats/teams/adelaide.html)

--- a/pyAFL/config.py
+++ b/pyAFL/config.py
@@ -1,1 +1,1 @@
-AFLTABLES_STATS_BASE_URL = "https://afltables.com/afl/stats/"
+AFLTABLES_STATS_BASE_URL = "https://afltables.com/afl/"

--- a/pyAFL/players/models.py
+++ b/pyAFL/players/models.py
@@ -42,6 +42,7 @@ class Player(object):
         """
 
         self.name = name.title()  # Convert to title case for URL string matching
+        self.name = self.name.replace("\n", "").strip()
         if url:
             self.url = url
         else:

--- a/pyAFL/players/models.py
+++ b/pyAFL/players/models.py
@@ -25,7 +25,7 @@ class Player(object):
     ...
     """
 
-    def __init__(self, name: str, team: str = None):
+    def __init__(self, name: str, url: str = None, team: str = None):
         """
         Constructs all the necessary attributes for the Player object.
          - If `name` returns two or more players, the (optional) parameter
@@ -42,10 +42,10 @@ class Player(object):
         """
 
         self.name = name.title()  # Convert to title case for URL string matching
-        self.team = (
-            team.title() if team else None
-        )  # Convert to title case for URL string matching
-        self.url = self._get_player_url()
+        if url:
+            self.url = url
+        else:
+            self.url = self._get_player_url()
 
     def _get_player_url(self):
         last_initial = self.name.split(" ")[1][0]
@@ -89,7 +89,7 @@ class Player(object):
         resp = requests.get(self.url)
         self._stat_html = resp.text
 
-        soup = BeautifulSoup(resp.text, "html.parser")
+        soup = BeautifulSoup(self._stat_html, "html.parser")
 
         all_dfs = pd.read_html(self._stat_html)
         season_dfs = pd.read_html(self._stat_html, match=r"[A-Za-z]* - [0-9]{4}")

--- a/pyAFL/players/models.py
+++ b/pyAFL/players/models.py
@@ -47,6 +47,12 @@ class Player(object):
         else:
             self.url = self._get_player_url()
 
+    def __repr__(self):
+        return f"<Player: {self.name}>"
+
+    def __str__(self):
+        return self.name
+
     def _get_player_url(self):
         last_initial = self.name.split(" ")[1][0]
         player_list_url = (

--- a/pyAFL/players/models.py
+++ b/pyAFL/players/models.py
@@ -50,7 +50,7 @@ class Player(object):
     def _get_player_url(self):
         last_initial = self.name.split(" ")[1][0]
         player_list_url = (
-            config.AFLTABLES_STATS_BASE_URL + f"players{last_initial}_idx.html"
+            config.AFLTABLES_STATS_BASE_URL + f"stats/players{last_initial}_idx.html"
         )
 
         resp = requests.get(player_list_url)

--- a/pyAFL/requests/requests.py
+++ b/pyAFL/requests/requests.py
@@ -95,6 +95,7 @@ def get(url: str, force_live: bool = False):
 
     if force_live:
         with requests_cache.disabled():
+            # NOTE - when force_live == True - the anchor-tag absolute URL fix is not applied!
             return requests.get(url)
     else:
         return requests.get(url)

--- a/pyAFL/requests/requests.py
+++ b/pyAFL/requests/requests.py
@@ -89,10 +89,6 @@ def get(url: str, force_live: bool = False):
             f"This function only takes URLs from `{config.AFLTABLES_STATS_BASE_URL}`"
         )
 
-    # get full filepath
-    base_url = config.AFLTABLES_STATS_BASE_URL
-    url_path = url.split(base_url)[-1]
-
     if force_live:
         with requests_cache.disabled():
             # NOTE - when force_live == True - the anchor-tag absolute URL fix is not applied!

--- a/pyAFL/teams/__init__.py
+++ b/pyAFL/teams/__init__.py
@@ -1,0 +1,68 @@
+from pyAFL.teams.models import Team
+
+ADE = Team("Adelaide", "adelaide")
+BRI = Team("Brisbane Lions", "brisbanel")
+BRB = Team("Brisbane Bears", "brisbaneb")
+CAR = Team("Carlton", "carlton")
+COL = Team("Collingwood", "collingwood")
+ESS = Team("Essendon", "essendon")
+FIZ = Team("Fitzroy", "fitzroy")
+FRE = Team("Fremantle", "fremantle")
+GEE = Team("Geelong", "geelong")
+GC = Team("Gold Coast", "goldcoast")
+GWS = Team("Greater Western Sydney", "gws")
+HAW = Team("Hawthorn", "hawthorn")
+MEL = Team("Melbourne", "melbourne")
+NOR = Team("North Melbourne", "kangaroos")
+POR = Team("Port Adelaide", "padelaide")
+RIC = Team("Richmond", "richmond")
+STK = Team("St Kilda", "stkilda")
+SYD = Team("Sydney", "swans")
+UNI = Team("University", "university")
+WCE = Team("West Coast", "westcoast")
+WBD = Team("Western Bulldogs", "bullldogs")
+
+ALL_TEAMS = [
+    ADE,
+    BRI,
+    BRB,
+    CAR,
+    COL,
+    ESS,
+    FIZ,
+    FRE,
+    GEE,
+    GC,
+    GWS,
+    HAW,
+    MEL,
+    NOR,
+    POR,
+    RIC,
+    STK,
+    SYD,
+    UNI,
+    WCE,
+    WBD,
+]
+
+CURRENT_TEAMS = [
+    ADE,
+    BRI,
+    CAR,
+    COL,
+    ESS,
+    FRE,
+    GEE,
+    GC,
+    GWS,
+    HAW,
+    MEL,
+    NOR,
+    POR,
+    RIC,
+    STK,
+    SYD,
+    WCE,
+    WBD,
+]

--- a/pyAFL/teams/models.py
+++ b/pyAFL/teams/models.py
@@ -41,6 +41,12 @@ class Team(object):
         self.all_time_players_url = f"https://afltables.com/afl/stats/teams/{url_identifier}.html"  # URL for all-time-players stats
         self.all_time_games_url = f"https://afltables.com/afl/teams/{url_identifier}/allgames.html"  # URL to all-time-games stats
 
+    def __repr__(self):
+        return f"<Team: {self.name}>"
+
+    def __str__(self):
+        return self.name
+
     @property
     def players(self):
         """

--- a/pyAFL/teams/models.py
+++ b/pyAFL/teams/models.py
@@ -142,11 +142,12 @@ class Team(object):
         for season_html in seasons:
             df = pd.read_html(str(season_html))[0]
             df.columns = df.columns.droplevel(1)
+            df = df.iloc[0:-2, :]
             dfs.append(df)
 
         games = pd.concat(dfs)
-        games = games.iloc[0:-2, :]
         games.index = pd.to_datetime(games.Date)
+        games = games.sort_index()
 
         games = games.rename(
             columns={"A": "Against", "F": "For", "R": "Result", "M": "Margin"}

--- a/pyAFL/teams/models.py
+++ b/pyAFL/teams/models.py
@@ -1,0 +1,71 @@
+from bs4 import BeautifulSoup
+
+from pyAFL.players.models import Player
+from pyAFL.requests import requests
+
+
+class Team(object):
+    """
+    A class to represent an AFL Team.
+
+    Attributes
+    ----------
+    name : str
+        team full name
+    players : object
+        list of all time players who played for the team (pyAFL player objects)
+
+    """
+
+    def __init__(self, name: str, url_identifier: str):
+        """
+        Constructs the Team object.
+
+        Parameters
+        ----------
+            name : str (required)
+                name of the person in format "[first] [last]"
+            url_identifier : str (required)
+                string parameter used in AFLtables URLs to identify team. Note that the naming convention changes from team to team
+                Examples: - for Adelaide: url_identifier = "adelaide" (see https://afltables.com/afl/stats/teams/adelaide.html)
+                          - for Greater Western Sydney: url_identifier = "gws" (see https://afltables.com/afl/stats/teams/gws.html)
+                          - for Western Bulldogs: url_identifier = "bullldogs" (see https://afltables.com/afl/stats/teams/bullldogs.html)
+
+        """
+
+        self.name = name.title()  # Convert to title case for URL string matching
+        self.all_time_players_url = f"https://afltables.com/afl/stats/teams/{url_identifier}.html"  # URL for all-time-players stats
+        self.all_time_games_url = f"https://afltables.com/afl/teams/{url_identifier}/allgames.html"  # URL to all-time-games stats
+
+    @property
+    def players(self):
+        """
+        NB - a network request will be made when this class property is called.
+        """
+
+        return self._get_players()
+
+    def _get_players(self):
+        """
+        Returns a list of pyAFL.Player objects for all players contained in `self.all_time_players_url`
+
+        Returns
+        ----------
+            players : list
+                list of pyAFL.Player objects
+
+        """
+        resp = requests.get(self.all_time_players_url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        player_table = soup.find("table")
+        player_table_body = player_table.find("tbody")
+        player_anchor_tags = player_table_body.findAll("a")
+
+        players = [
+            Player(player.text, url=player.attrs.get("href"))
+            for player in player_anchor_tags
+        ]
+
+        return players
+

--- a/pyAFL/teams/tests/test_models.py
+++ b/pyAFL/teams/tests/test_models.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from pyAFL.base.exceptions import LookupError
 from pyAFL.players.models import Player
+from pyAFL.teams import ALL_TEAMS, CURRENT_TEAMS
 from pyAFL.teams.models import Team
 from pyAFL.requests import requests
 
@@ -14,8 +15,6 @@ class TestTeamModel:
             Team()
 
     def test_team_property_players(self):
-        from pyAFL.teams import ALL_TEAMS
-
         test_team = ALL_TEAMS[0]
         players = test_team.players
 
@@ -25,9 +24,8 @@ class TestTeamModel:
         assert "https://afltables.com/afl/stats/players" in players[0].url
 
     def test_team_method_season_stats_invalid_year(self):
-        from pyAFL.teams import ALL_TEAMS
-
         test_team = ALL_TEAMS[0]
+
         with pytest.raises(Exception) as e1:
             test_team.season_stats(123)
         with pytest.raises(Exception) as e2:
@@ -37,10 +35,16 @@ class TestTeamModel:
         assert "Could not find season stats for year" in str(e2)
 
     def test_team_method_season_stats_valid_year(self):
-        from pyAFL.teams import CURRENT_TEAMS
-
         test_team = CURRENT_TEAMS[0]
         season_stats = test_team.season_stats(2019)
 
         assert isinstance(season_stats, pd.DataFrame)
         assert "Player" in season_stats.columns
+
+    def test_team_property_games(self):
+        test_team = ALL_TEAMS[0]
+        games = test_team.games
+
+        assert isinstance(games, pd.DataFrame)
+        assert isinstance(games.index, pd.DatetimeIndex)
+        assert len(games.index) > len(games.loc["2019-01-01":"2019-08-01"].index)

--- a/pyAFL/teams/tests/test_models.py
+++ b/pyAFL/teams/tests/test_models.py
@@ -1,0 +1,24 @@
+import pytest
+from unittest import mock
+
+from pyAFL.base.exceptions import LookupError
+from pyAFL.players.models import Player
+from pyAFL.teams.models import Team
+from pyAFL.requests import requests
+
+
+class TestTeamModel:
+    def test_team_name_none_throws_exception(self):
+        with pytest.raises(TypeError):
+            Team()
+
+    def test_team_property_players(self):
+        from pyAFL.teams import ALL_TEAMS
+
+        test_team = ALL_TEAMS[0]
+        players = test_team.players
+
+        assert isinstance(players, (list, tuple))
+        assert len(players) > 0
+        assert isinstance(players[0], Player)
+        assert "https://afltables.com/afl/stats/players" in players[0].url

--- a/pyAFL/teams/tests/test_models.py
+++ b/pyAFL/teams/tests/test_models.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 from unittest import mock
 
@@ -22,3 +23,24 @@ class TestTeamModel:
         assert len(players) > 0
         assert isinstance(players[0], Player)
         assert "https://afltables.com/afl/stats/players" in players[0].url
+
+    def test_team_method_season_stats_invalid_year(self):
+        from pyAFL.teams import ALL_TEAMS
+
+        test_team = ALL_TEAMS[0]
+        with pytest.raises(Exception) as e1:
+            test_team.season_stats(123)
+        with pytest.raises(Exception) as e2:
+            test_team.season_stats(2050)
+
+        assert "Could not find season stats for year" in str(e1)
+        assert "Could not find season stats for year" in str(e2)
+
+    def test_team_method_season_stats_valid_year(self):
+        from pyAFL.teams import CURRENT_TEAMS
+
+        test_team = CURRENT_TEAMS[0]
+        season_stats = test_team.season_stats(2019)
+
+        assert isinstance(season_stats, pd.DataFrame)
+        assert "Player" in season_stats.columns


### PR DESCRIPTION
Addresses Issue #3 
- Create the Team model: a object for holding Team information.
- All current and former Teams are automatically instantiated in the pyAFL.teams module. Team objects can be imported by their team abbreviation. For example: from pyAFL.teams import ADE, SYD, RIC
- The API allows querying historical team players (e.g. ADE.players)
- The API allows querying historical game results (e.g. ADE.games)