### PR TITLE
Bug/player name capitalisation

### DIFF
--- a/pyAFL/players/models.py
+++ b/pyAFL/players/models.py
@@ -65,7 +65,9 @@ class Player(object):
 
         url_list = soup.findAll(
             "a",
-            href=re.compile(f"players/{self.name[0]}/{self.name.replace(' ', '_')}"),
+            href=re.compile(
+                f"players/{self.name[0]}/{self.name.replace(' ', '_')}", re.I
+            ),
         )
 
         # If no matches found, raise LookupError

--- a/pyAFL/players/tests/test_models.py
+++ b/pyAFL/players/tests/test_models.py
@@ -24,6 +24,10 @@ class TestPlayerModel:
             Player("Tony Lockett")._get_player_url()
             == "https://afltables.com/afl/stats/players/T/Tony_Lockett.html"
         )
+        assert (
+            Player("Duncan MacGregor")._get_player_url()
+            == "https://afltables.com/afl/stats/players/D/Duncan_MacGregor.html"
+        )
 
     def test_player_classmethod_get_player_url_failure(self):
         with pytest.raises(LookupError) as e:


### PR DESCRIPTION
Patches issue #10 

Problem:

- players search did not work for players with capitalisation in the middle of their name (e.g. Duncan MacGregor)

Patch:

- Make string match case insensitive