### PR TITLE
fix: add `base/__init__.py` for module auto-discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="pyAFL",
-    version="0.2.0",
+    version="0.2.1",
     description="Python data fetching library for the Australian Football League",
     long_description="pyAFL is a AFL (Australian Football League) data fetching libary. It scrapes data from https://afltables.com/ and converts results to structured Python objects for easier analytics.",
     url="https://github.com/RamParameswaran/pyAFL",


### PR DESCRIPTION
- fixes issue #12
- adds `base/__init__.py` so that the `base/` directory is found by `setup.py -> find_packages()` during PyPI packaging.