### PR TITLE
fix: naming conflict for Adelaide and Port Adelaide

### DIFF
--- a/pyAFL/teams/models.py
+++ b/pyAFL/teams/models.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from bs4 import BeautifulSoup
+import re
 
 from pyAFL.base.exceptions import LookupError
 from pyAFL.players.models import Player
@@ -108,8 +109,10 @@ class Team(object):
 
         for table in team_tables:
             if table.find("th"):
-                if self.name in table.find("th").text:
+                stripped_string = table.find("th").text.replace("/n", "").strip()
+                if stripped_string.startswith(self.name):
                     df = pd.read_html(str(table))
+                    break
 
         if df is None:
             raise LookupError(

--- a/pyAFL/teams/tests/test_models.py
+++ b/pyAFL/teams/tests/test_models.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+import pyAFL.teams
 from pyAFL.players.models import Player
 from pyAFL.teams import ALL_TEAMS, CURRENT_TEAMS
 from pyAFL.teams.models import Team
@@ -37,6 +38,16 @@ class TestTeamModel:
 
         assert isinstance(season_stats, pd.DataFrame)
         assert "Player" in season_stats.columns
+
+    def test_team_method_season_stats_adelaide_and_portadelaide_naming_conflict(self):
+        adelaide_crows = pyAFL.teams.ADE
+        port_adelaide = pyAFL.teams.POR
+
+        adelaide_season_stats = adelaide_crows.season_stats(2019)
+        port_adelaide_season_stats = port_adelaide.season_stats(2019)
+
+        assert port_adelaide_season_stats.Player[0] == "Boak, Travis"  # We expect to find Travis Boak in Port Adelaide
+        assert adelaide_season_stats.Player[0] == "Crouch, Brad"  # We expect to find Brad Crouch in Adelaide Crows
 
     def test_team_property_games(self):
         test_team = ALL_TEAMS[0]


### PR DESCRIPTION
Addresses issue #23.

Fixes bug in `Team.season_stats` where Port Adelaide stats actually return Adelaide.
This was due to a naive implementation of `if {team_name} in String`, which could not differentiate between Adelaide AND Port Adelaide.

Shout-out to @polar1510 who raises PR #22 10 months ago, which aimed to fix the same bug, and brought attention to this fix.